### PR TITLE
remove pytest optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,20 +43,6 @@ You can trace all the HTTP requests performed by a script
 pyhttpdbg --script filename.py [arg1 --arg2 ...]
 ```
 
-### pytest
-
-You can trace all the HTTP requests performed during your tests
-
-```console
-pyhttpdbg -m pytest [arg1 --arg2 ...]
-```
-
-If you use the `pytest-xdist` plugin to execute your tests in parallel, then you must install the `pytest-httpdbg` plugin if you want to trace the requests done by the pytest workers.
-
-```console
-pip install httpdbg[pytest]
-```
-
 ### module
 
 You can trace all the HTTP requests performed by a library module run as a script using the `-m` command line argument.
@@ -66,6 +52,16 @@ For example, you can view which HTTP requests are performed by `pip` when you in
 ```console
 pyhttpdbg -m pip install hookdns --upgrade
 ```
+
+### test frameworks
+
+You can trace all HTTP requests made during your tests (pytest, unittest).
+
+```console
+pyhttpdbg -m pytest [arg1 --arg2 ...]
+```
+
+In that case, the requests will be grouped by test, and any requests made within a fixture or the setup/teardown methods will be identified by a tag.
 
 ## Initiators
 

--- a/httpdbg/__init__.py
+++ b/httpdbg/__init__.py
@@ -3,6 +3,6 @@ from httpdbg.hooks.all import httprecord
 from httpdbg.records import HTTPRecords
 
 
-__version__ = "0.32.0"
+__version__ = "0.32.1"
 
 __all__ = ["httprecord", "HTTPRecords"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,6 @@ no_implicit_optional = false
 disable_error_code= ["method-assign",]
 files = ["httpdbg"]
 
-[project.optional-dependencies]
-pytest = ["pytest-httpdbg>=0.6.0"]
-
 [project.urls]
 Source = "https://github.com/cle-b/httpdbg/"
 Documentation = "https://httpdbg.readthedocs.io/"


### PR DESCRIPTION
`pytest-httpdbg` is no longer needed, even when using `pytest-xdist.`