### PR TITLE
fix flask integration

### DIFF
--- a/httpdbg/hooks/flask.py
+++ b/httpdbg/hooks/flask.py
@@ -13,7 +13,9 @@ from httpdbg.records import HTTPRecords
 
 def set_hook_flask_endpoint(records: HTTPRecords, method: Callable):
 
-    @wraps(method)
+    @wraps(
+        method
+    )  # to avoid AssertionError: View function mapping is overwriting an existing endpoint function: hook
     def hook(*args, **kwargs):
 
         with httpdbg_endpoint(
@@ -28,6 +30,8 @@ def set_hook_flask_endpoint(records: HTTPRecords, method: Callable):
     return hook
 
 
+# we must not apply the hook more than once on a mapped endpoint function
+# AssertionError: View function mapping is overwriting an existing endpoint function: xxxx
 already_mapped = {}
 
 

--- a/httpdbg/hooks/flask.py
+++ b/httpdbg/hooks/flask.py
@@ -9,11 +9,11 @@ from httpdbg.hooks.utils import decorate
 from httpdbg.hooks.utils import undecorate
 from httpdbg.initiator import httpdbg_endpoint
 from httpdbg.records import HTTPRecords
+from httpdbg.utils import get_new_uuid
 
 
 def set_hook_flask_endpoint(records: HTTPRecords, method: Callable):
 
-    @wraps(method)
     def hook(*args, **kwargs):
 
         with httpdbg_endpoint(
@@ -24,6 +24,10 @@ def set_hook_flask_endpoint(records: HTTPRecords, method: Callable):
         ):
             ret = method(*args, **kwargs)
         return ret
+    
+    # we must generate a unique function name for each hook, to avoid the following error:
+    # AssertionError: View function mapping is overwriting an existing endpoint function: hook    
+    hook.__name__ = f"hook_{get_new_uuid()}"
 
     return hook
 

--- a/httpdbg/hooks/http.py
+++ b/httpdbg/hooks/http.py
@@ -14,7 +14,7 @@ def set_hook_for_http_server_handle_one_request(records: HTTPRecords, method: Ca
     def hook(*args, **kwargs):
 
         # the group label/full_label will be updated when the endpoint method will be called
-        with httpdbg_group(records, "one request", "", updatable=True):
+        with httpdbg_group(records, "one request", ""):
             ret = method(*args, **kwargs)
 
         return ret

--- a/httpdbg/hooks/http.py
+++ b/httpdbg/hooks/http.py
@@ -14,7 +14,7 @@ def set_hook_for_http_server_handle_one_request(records: HTTPRecords, method: Ca
     def hook(*args, **kwargs):
 
         # the group label/full_label will be updated when the endpoint method will be called
-        with httpdbg_group(records, "one request", ""):
+        with httpdbg_group(records, "one request", "", updatable=True):
             ret = method(*args, **kwargs)
 
         return ret

--- a/httpdbg/hooks/pytest.py
+++ b/httpdbg/hooks/pytest.py
@@ -34,7 +34,7 @@ def set_hook_for_pytest_runtest(records: HTTPRecords, method: Callable):
         if "item" in callargs:
             full_label = getattr(callargs["item"], "nodeid", "unknown test")
             label = getattr(callargs["item"], "name", "unknown test")
-            with httpdbg_group(records, label, full_label):
+            with httpdbg_group(records, label, full_label, updatable=False):
                 return method(*args, **kwargs)
         else:
             return method(*args, **kwargs)

--- a/httpdbg/hooks/unittest.py
+++ b/httpdbg/hooks/unittest.py
@@ -36,7 +36,7 @@ def set_hook_for_unittest_run(records: HTTPRecords, method: Callable):
                     test_module_path = os.path.relpath(test_module_path)
                     full_label = f"{test_module_path}::{full_label}"
 
-            with httpdbg_group(records, label, full_label):
+            with httpdbg_group(records, label, full_label, updatable=False):
                 ret = method(*args, **kwargs)
         else:
             ret = method(*args, **kwargs)
@@ -79,7 +79,7 @@ def set_hook_for_unittest_class_setup(records: HTTPRecords, method: Callable):
                 test_module_path = os.path.relpath(test_module_path)
                 full_label = f"{test_module_path}::{full_label}"
 
-            with httpdbg_group(records, label, full_label):
+            with httpdbg_group(records, label, full_label, updatable=False):
                 return method(*args, **kwargs)
         else:
             return method(*args, **kwargs)
@@ -116,7 +116,7 @@ def set_hook_for_unittest_class_teardown(records: HTTPRecords, method: Callable)
                     test_module_path = os.path.relpath(test_module_path)
                     full_label = f"{test_module_path}::{full_label}"
 
-            with httpdbg_group(records, label, full_label):
+            with httpdbg_group(records, label, full_label, updatable=False):
                 return method(*args, **kwargs)
         else:
             return method(*args, **kwargs)
@@ -147,7 +147,7 @@ def set_hook_for_unittest_module_setup(records: HTTPRecords, method: Callable):
                 test_module_path = os.path.relpath(test_module_path)
                 full_label = f"{test_module_path}::setUpModule"
 
-            with httpdbg_group(records, label, full_label):
+            with httpdbg_group(records, label, full_label, updatable=False):
                 return method(*args, **kwargs)
         else:
             return method(*args, **kwargs)
@@ -191,7 +191,7 @@ def set_hook_for_unittest_module_teardown(records: HTTPRecords, method: Callable
                     test_module_path = os.path.relpath(test_module_path)
                     full_label = f"{test_module_path}::tearDownModule"
 
-            with httpdbg_group(records, label, full_label):
+            with httpdbg_group(records, label, full_label, updatable=False):
                 return method(*args, **kwargs)
         else:
             return method(*args, **kwargs)

--- a/httpdbg/initiator.py
+++ b/httpdbg/initiator.py
@@ -66,7 +66,7 @@ class Initiator:
 
 
 class Group:
-    def __init__(self, label: str, full_label: str, updatable: bool = False):
+    def __init__(self, label: str, full_label: str, updatable: bool):
         self.id: str = get_new_uuid()
         self.label: str = label
         self.full_label: str = full_label
@@ -324,7 +324,7 @@ def httpdbg_group(
     label: str,
     full_label: str,
     update: bool = False,
-    updatable: bool = False,
+    updatable: bool = True,
 ) -> Generator[Group, None, None]:
 
     # A group is considered set if the environment variable exists and the group


### PR DESCRIPTION
Fix the error `AssertionError: View function mapping is overwriting an existing endpoint function: xxxx` which happened in that case:
```python
@app.route("/anything", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "TRACE"])
@app.route(
    "/anything/<path:anything>",
    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "TRACE"],
)
def view_anything(anything=None):
   ...
```

Fix the group by test feature which was broken by `httpdbg_endpoint`. 