### PR TITLE
hook function for custom initiator only if imported

### DIFF
--- a/httpdbg/__init__.py
+++ b/httpdbg/__init__.py
@@ -3,6 +3,6 @@ from httpdbg.hooks.all import httprecord
 from httpdbg.records import HTTPRecords
 
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 __all__ = ["httprecord", "HTTPRecords"]

--- a/httpdbg/hooks/generic.py
+++ b/httpdbg/hooks/generic.py
@@ -79,7 +79,7 @@ def hook_generic(
 
             if (
                 name not in already_hooked
-            ):  # will avoid parsing the same module many time
+            ):  # avoids parsing the same module multiple times
                 if (records is not None) and initiators:
                     if (name in initiators) or (
                         any(
@@ -93,7 +93,7 @@ def hook_generic(
                         already_hooked.append(name)
                         hooks += list_callables_from_module(records, name)
 
-            # we temporary restore the original builtin import method to avoid an infinite reccursion inside the import itself
+            # we temporarily restore the original built-in import function to avoid infinite recursion during import
             __custom_import = builtins.__import__
             builtins.__import__ = original_builtin_import
             r = original_builtin_import(

--- a/httpdbg/hooks/generic.py
+++ b/httpdbg/hooks/generic.py
@@ -89,7 +89,7 @@ def hook_generic(
                             ]
                         )
                     ):
-                        logger().info(f"HOOK IMPORT {name} - fromlist={fromlist}")
+                        logger().debug(f"HOOK IMPORT {name} - fromlist={fromlist}")
                         already_hooked.append(name)
                         hooks += list_callables_from_module(records, name)
 

--- a/httpdbg/hooks/urllib3.py
+++ b/httpdbg/hooks/urllib3.py
@@ -52,7 +52,7 @@ def hook_urllib3(records: HTTPRecords) -> Generator[None, None, None]:
             )
         # v2
         if hasattr(urllib3, "request"):
-            urllib3.request = decorate(records, urllib3.request, set_hook_for_urllib3)
+            urllib3.request = decorate(records, urllib3.request, set_hook_for_urllib3)  # type: ignore[arg-type]
 
         hooks = True
     except ImportError:
@@ -70,4 +70,4 @@ def hook_urllib3(records: HTTPRecords) -> Generator[None, None, None]:
             )
         # v2
         if hasattr(urllib3, "request"):
-            urllib3.request = undecorate(urllib3.request)
+            urllib3.request = undecorate(urllib3.request)  # type: ignore[arg-type]

--- a/httpdbg/hooks/utils.py
+++ b/httpdbg/hooks/utils.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
+from collections.abc import Callable
 import inspect
+import typing
 
 from httpdbg.log import logger
+
+if typing.TYPE_CHECKING:
+    from httpdbg.records import HTTPRecords
 
 
 def getcallargs(original_method, *args, **kwargs):
@@ -28,12 +33,12 @@ def getcallargs(original_method, *args, **kwargs):
     return callargs
 
 
-def decorate(records, method, hook):
+def decorate(records: "HTTPRecords", method: Callable, hook: Callable):
     ori = method
     method = hook(records, method)
-    method.__httpdbg__ = ori
+    method.__httpdbg__ = ori  # type: ignore[attr-defined]
     return method
 
 
-def undecorate(method):
-    return method.__httpdbg__
+def undecorate(method: Callable):
+    return method.__httpdbg__  # type: ignore[attr-defined]


### PR DESCRIPTION
Modify how we hook functions for the custom initiator option by applying the patch only to imported modules. This should resolve the issue described [here](https://github.com/cle-b/httpdbg/issues/157#issuecomment-2458495611).

python:
```
(venv) $ python
Python 3.12.3 (main, Feb  4 2025, 14:48:35) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import stripe
>>> stripe.api_version
'2025-04-30.basil'
>>> import stripe.api_version
>>> stripe.api_version
<module 'stripe.api_version' from '/home/cle/tmp/venv/lib/python3.12/site-packages/stripe/api_version.py'>
```

httpdbg v1.2.1:
``` 
(venv) $ pyhttpdbg -i stripe
.... - - .--. -.. -... --. .... - - .--. -.. -... --. .... - - .--. -.. -... --.
  httpdbg - HTTP(S) requests available at http://localhost:4567/
.... - - .--. -.. -... --. .... - - .--. -.. -... --. .... - - .--. -.. -... --.
Python 3.12.3 (main, Feb  4 2025, 14:48:35) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsoleWithHistory)
>>> import stripe
>>> stripe.api_version
<module 'stripe.api_version' from '/home/cle/tmp/venv/lib/python3.12/site-packages/stripe/api_version.py'>
```
httpdbg now:
``` 
(venv) $ pyhttpdbg
.... - - .--. -.. -... --. .... - - .--. -.. -... --. .... - - .--. -.. -... --.
  httpdbg - HTTP(S) requests available at http://localhost:4909/
.... - - .--. -.. -... --. .... - - .--. -.. -... --. .... - - .--. -.. -... --.
Python 3.12.3 (main, Feb  4 2025, 14:48:35) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsoleWithHistory)
>>> import stripe
>>> stripe.api_version
'2025-04-30.basil'
>>> import stripe.api_version
>>> stripe.api_version
<module 'stripe.api_version' from '/home/cle/dev/httpdbg/venv/lib/python3.12/site-packages/stripe/api_version.py'>
```
