### PR TITLE
fix short stack description for initiator

### DIFF
--- a/httpdbg/__init__.py
+++ b/httpdbg/__init__.py
@@ -3,6 +3,6 @@ from httpdbg.hooks.all import httprecord
 from httpdbg.records import HTTPRecords
 
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"
 
 __all__ = ["httprecord", "HTTPRecords"]

--- a/httpdbg/initiator.py
+++ b/httpdbg/initiator.py
@@ -211,9 +211,8 @@ def construct_call_str(original_method, *args, **kwargs):
                 return f'"{v}"'
             else:
                 return str(v)
-        except:
+        except Exception:
             return "-?-"  # in case __retr__ or __str__ is broken
-
 
     callargs = getcallargs(original_method, *args, **kwargs)
 

--- a/httpdbg/initiator.py
+++ b/httpdbg/initiator.py
@@ -205,11 +205,15 @@ def extract_short_stack_from_file(
 
 def construct_call_str(original_method, *args, **kwargs):
 
-    def print_v(v):
-        if isinstance(v, str):
-            return f'"{v}"'
-        else:
-            return v
+    def print_v(v) -> str:
+        try:
+            if isinstance(v, str):
+                return f'"{v}"'
+            else:
+                return str(v)
+        except:
+            return "-?-"  # in case __retr__ or __str__ is broken
+
 
     callargs = getcallargs(original_method, *args, **kwargs)
 

--- a/tests/initiator_pck/repr_exception.py
+++ b/tests/initiator_pck/repr_exception.py
@@ -1,0 +1,14 @@
+import requests
+
+
+class BrokenREPR:
+
+    def __init__(self, url):
+        self.url = url
+
+    def __repr__(self):
+        boum  # noqa F821
+
+
+def get(br):
+    requests.get(br.url)

--- a/tests/test_initiator.py
+++ b/tests/test_initiator.py
@@ -165,3 +165,15 @@ def test_initiator_add_package_fnc(httpbin):
         == "requests.get(url)  # method"
     )
     assert records.initiators[records[4].initiator_id].label == "await client.get(url)"
+
+
+def test_exception_in_initiator(httpbin):
+
+    with httprecord(initiators=["tests.initiator_pck"]) as records:
+        from tests.initiator_pck.repr_exception import BrokenREPR, get
+
+        br = BrokenREPR(f"{httpbin.url}/get")
+        get(br)
+
+    assert records.initiators[records[0].initiator_id].label == "get(br)"
+    assert "br=-?-" in records.initiators[records[0].initiator_id].short_stack


### PR DESCRIPTION
lib repr_exception.py:
```python
import requests


class BrokenREPR:

    def __init__(self, url):
        self.url = url

    def __repr__(self):
        boum  # noqa F821


def get(br):
    requests.get(br.url)
```

script demo.py
```python
from repr_exception import BrokenREPR, get

br = BrokenREPR(f"https://www.example.com")
get(br)
```

pyhttpdbg -i tests.initiator_pck.repr_exception --script demo.py

before:
```
.... - - .--. -.. -... --. .... - - .--. -.. -... --. .... - - .--. -.. -... --.
  httpdbg - HTTP(S) requests available at http://localhost:4909/
.... - - .--. -.. -... --. .... - - .--. -.. -... --. .... - - .--. -.. -... --.
Traceback (most recent call last):
  File "/home/cle/dev/httpdbg/httpdbg/mode_script.py", line 23, in run_script
    runpy.run_path(argv[0], run_name="__main__")
  File "<frozen runpy>", line 286, in run_path
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "demo.py", line 4, in <module>
    get(br)
  File "/home/cle/dev/httpdbg/httpdbg/hooks/generic.py", line 40, in hook
    with httpdbg_initiator(
  File "/usr/lib/python3.12/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/home/cle/dev/httpdbg/httpdbg/initiator.py", line 256, in httpdbg_initiator
    short_stack += "----------\n" + construct_call_str(
                                    ^^^^^^^^^^^^^^^^^^^
  File "/home/cle/dev/httpdbg/httpdbg/initiator.py", line 229, in construct_call_str
    r += f"    {k}={print_v(v)},\n"
                    ^^^^^^^^^^
  File "/home/cle/dev/httpdbg/httpdbg/initiator.py", line 212, in print_v
    return str(v)
           ^^^^^^
  File "/home/cle/dev/httpdbg/tests/initiator_pck/repr_exception.py", line 10, in __repr__
    boum  # noqa F821
    ^^^^
NameError: name 'boum' is not defined
.... - - .--. -.. -... --. .... - - .--. -.. -... --. .... - - .--. -.. -... --.
  httpdbg - HTTP(S) requests available at http://localhost:4909/
.... - - .--. -.. -... --. .... - - .--. -.. -... --. .... - - .--. -.. -... --.
Waiting until all the requests have been loaded in the web interface.
Press Ctrl+C to quit.
```

after:
![image](https://github.com/user-attachments/assets/76a12163-2b2d-4b19-aa87-af96f2eebd13)
