### PR TITLE
fix http 100 continue

### DIFF
--- a/httpdbg/__init__.py
+++ b/httpdbg/__init__.py
@@ -3,6 +3,6 @@ from httpdbg.hooks.all import httprecord
 from httpdbg.records import HTTPRecords
 
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 
 __all__ = ["httprecord", "HTTPRecords"]

--- a/httpdbg/records.py
+++ b/httpdbg/records.py
@@ -229,6 +229,7 @@ class HTTPRecord:
         self.is_client: bool = is_client
         if tbegin:
             self.tbegin = tbegin
+        self.http100: bool = False
 
     @property
     def url(self) -> str:
@@ -298,6 +299,14 @@ class HTTPRecord:
     def receive_data(self, data: bytes):
         if self.is_client:
             self.response.rawdata += data
+            if self.response.rawdata.lower() in {
+                b"http/1.1 100 continue\r\n\r\n",
+                b"http/1.0 100 continue\r\n\r\n"
+            }:
+                # in case we receive an HTTP 100 code, we do not record it as the final HTTP response headers
+                # but we keep the information to display it in the UI
+                self.http100 = True
+                self.response.rawdata = bytes() # very important to have the HTTP request body recorded. 
         else:
             self.request.rawdata += data
 

--- a/httpdbg/records.py
+++ b/httpdbg/records.py
@@ -301,12 +301,14 @@ class HTTPRecord:
             self.response.rawdata += data
             if self.response.rawdata.lower() in {
                 b"http/1.1 100 continue\r\n\r\n",
-                b"http/1.0 100 continue\r\n\r\n"
+                b"http/1.0 100 continue\r\n\r\n",
             }:
                 # in case we receive an HTTP 100 code, we do not record it as the final HTTP response headers
                 # but we keep the information to display it in the UI
                 self.http100 = True
-                self.response.rawdata = bytes() # very important to have the HTTP request body recorded. 
+                self.response.rawdata = (
+                    bytes()
+                )  # very important to have the HTTP request body recorded.
         else:
             self.request.rawdata += data
 

--- a/httpdbg/webapp/api.py
+++ b/httpdbg/webapp/api.py
@@ -18,6 +18,7 @@ class RequestPayload(JSONEncoder):
             "urlext": req.urlext,
             "method": req.method,
             "status_code": req.status_code,
+            "http100": req.http100,
             "reason": req.reason,
             "request": None,
             "response": None,

--- a/httpdbg/webapp/api.py
+++ b/httpdbg/webapp/api.py
@@ -91,6 +91,7 @@ class RequestListPayload(JSONEncoder):
                 "netloc": req.netloc,
                 "urlext": req.urlext,
                 "status_code": req.status_code,
+                "http100": req.http100,
                 "protocol": req.protocol,
                 "reason": req.reason,
                 "verb": req.method,

--- a/httpdbg/webapp/static/index.htm
+++ b/httpdbg/webapp/static/index.htm
@@ -274,7 +274,7 @@
                                        <b>{{ method }}</b> <a href="{{ url }}">{{ url }}</a>
                                        <hr>
                                             <span class="header-cookie-key">status:</span>
-                                            <span class="header-cookie-value">{{ status_code }} {{ reason }}</span>
+                                            <span class="header-cookie-value">{{ status_code }} {{ reason }} {{#http100}}(after 100 Continue){{/http100}}</span>
                                             <br>
                                             {{#protocol}}
                                             <span class="header-cookie-key">protocol:</span>


### PR DESCRIPTION
This PR fixes the support of the HTTP 100 Continue status code.

before (httdbg 1.2.5):

<img width="1292" height="536" alt="image" src="https://github.com/user-attachments/assets/312384e6-caec-4da6-8f01-2f7c5330e64f" />
<img width="1298" height="347" alt="image" src="https://github.com/user-attachments/assets/e10b4a27-f562-4810-a3e7-44cc3c6ac174" />


after:

<img width="1295" height="441" alt="image" src="https://github.com/user-attachments/assets/0e9168f2-7333-4bf8-a7d0-1f1c0cb39d4c" />

<img width="1294" height="342" alt="image" src="https://github.com/user-attachments/assets/c065dee7-2cdd-4471-9264-374e90a48101" />
