### PR TITLE
(performance) initiator/stacktrace - reduce io

### DIFF
--- a/httpdbg/__init__.py
+++ b/httpdbg/__init__.py
@@ -2,6 +2,6 @@ from httpdbg.hooks.all import httprecord
 from httpdbg.records import HTTPRecords
 
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 __all__ = ["httprecord", "HTTPRecords"]


### PR DESCRIPTION
This PR aims to reduce the performance impact of tracing using httpdbg. 

### the investigation

* start a HTTP server:
   * `python -m fastapi run tests/demo_fastapi.py`
* profile the execution of a script that performs 1000 HTTP requests and compare the results
  * using httpdbg (the latest version -> 2.0.1):
     * `pyhttpdbg -q -m cProfile -o pyhttpdbg201.perf tests/demo_client_load.py`  

python -> `snakeviz python.perf`
<img width="1272" height="326" alt="image" src="https://github.com/user-attachments/assets/8d0fa1ca-5a7b-4c57-b50c-b5591d5cb758" />

The `io.open` and `'splitlines' of 'str'` entries are due to the fact we opened the same python files many time to extract the lines of code to enrich the stack trace for the initiator. 

### the fix

To reduce the number of i/o, we use cache using the `linecache.getline` function (which is already used by the traceback package) and the `functools.cache` ( for our own internal methods).

* profile the execution of a script that performs 1000 HTTP requests using the fixed code and compare the results
   *  using httpdbg (with the optimization):
       * `pyhttpdbg -q -m cProfile -o pyhttpdbgopti.perf tests/demo_client_load.py`
       
python -> `pyhttpdbgopti.perf`

<img width="1254" height="292" alt="image" src="https://github.com/user-attachments/assets/2b860c6f-7820-4dbf-8894-e7838f52cbfa" />

### the validation

To validate the improvement, we execute the script 3 * 10 times and graph the results using a boxplot.

 ```
for i in {1..10}; do python tests/demo_client_load.py >> validation_python.txt; done
git switch main
for i in {1..10}; do pyhttpdbg -q --script tests/demo_client_load.py >> validation_httpdbg201.txt; done
git switch -
for i in {1..10}; do pyhttpdbg -q --script tests/demo_client_load.py >> validation_httpdbgcurrent.txt; done
```

<img width="794" height="593" alt="image" src="https://github.com/user-attachments/assets/1a20f17b-e4ea-411c-9e8c-a6b35f387055" />
